### PR TITLE
Add VS Code dev container configuration

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,13 @@
+{
+  "name": "typescript-starter",
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:0-20",
+  "postCreateCommand": "npm install",
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "dbaeumer.vscode-eslint",
+        "esbenp.prettier-vscode"
+      ]
+    }
+  }
+}

--- a/README.md
+++ b/README.md
@@ -1,2 +1,12 @@
 # typescript-starter
 This is my typescript starter template that includes jest for testing, eslint for linting, winston for logging and has some helpful scripts for dev.
+
+## Development Container
+
+This project includes a [Dev Container](https://containers.dev/) configuration for VS Code. With the Dev Containers extension installed, you can open the repository in a containerized environment with all dependencies pre-installed:
+
+1. Install Docker and the Dev Containers extension.
+2. Open the command palette and select **Dev Containers: Open Folder in Container...**.
+
+The container uses the `mcr.microsoft.com/devcontainers/typescript-node:0-20` image and runs `npm install` after creation.
+


### PR DESCRIPTION
## Summary
- add .devcontainer setup using typescript-node image and install deps on create
- document dev container usage in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b43c4cf45c832b942a8d3fc698953a