### PR TITLE
chore: set up Prettier and integrate with ESLint

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -7,7 +7,8 @@
         "eslint:recommended",
         "plugin:@typescript-eslint/eslint-recommended",
         "plugin:@typescript-eslint/recommended",
-        "plugin:node/recommended"
+        "plugin:node/recommended",
+        "prettier"
     ],
     "parser": "@typescript-eslint/parser",
     "parserOptions": {
@@ -20,21 +21,11 @@
     ],
     "rules": {
         "no-console": "off",
-        "semi": [
-            "warn",
-            "always"
-        ],
-        "quotes": [
-            "warn",
-            "single"
-        ],
         "block-scoped-var": "warn",
         "eqeqeq": "warn",
         "no-var": "warn",
         "prefer-const": "warn",
-        "eol-last": "warn",
         "prefer-arrow-callback": "warn",
-        "no-trailing-spaces": "warn",
         "node/no-missing-import": "off",
         "node/no-unsupported-features/es-syntax": "off",
         "node/no-unpublished-import": [

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,6 @@
+{
+  "singleQuote": true,
+  "semi": true,
+  "trailingComma": "all",
+  "printWidth": 80
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+  "editor.formatOnSave": true,
+  "editor.defaultFormatter": "esbenp.prettier-vscode"
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,9 +18,11 @@
         "@typescript-eslint/parser": "^7.18.0",
         "eslint": "^8.57.1",
         "eslint-config-google": "^0.14.0",
+        "eslint-config-prettier": "^10.1.8",
         "eslint-plugin-node": "^11.1.0",
         "jest": "^29.7.0",
         "onchange": "^7.1.0",
+        "prettier": "^3.6.2",
         "ts-jest": "^29.4.1",
         "ts-node": "^10.9.2",
         "typescript": "^5.9.2"
@@ -2492,6 +2494,22 @@
         "eslint": ">=5.16.0"
       }
     },
+    "node_modules/eslint-config-prettier": {
+      "version": "10.1.8",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-10.1.8.tgz",
+      "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "eslint-config-prettier": "bin/cli.js"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint-config-prettier"
+      },
+      "peerDependencies": {
+        "eslint": ">=7.0.0"
+      }
+    },
     "node_modules/eslint-plugin-es": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/eslint-plugin-es/-/eslint-plugin-es-3.0.1.tgz",
@@ -4586,6 +4604,22 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.6.2.tgz",
+      "integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/pretty-format": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "lint": "eslint -c .eslintrc.json --ext .ts --no-eslintrc src --fix",
     "check": "npm run lint && npm run build:fast",
     "watch": "onchange \"src/**/*.ts\" \"src/*.ts\" -e \"dist/*\" \"tests/*\" -- npm run check",
-    "test": "jest"
+    "test": "jest",
+    "format": "prettier --write ."
   },
   "repository": {
     "type": "git",
@@ -36,9 +37,11 @@
     "@typescript-eslint/parser": "^7.18.0",
     "eslint": "^8.57.1",
     "eslint-config-google": "^0.14.0",
+    "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-node": "^11.1.0",
     "jest": "^29.7.0",
     "onchange": "^7.1.0",
+    "prettier": "^3.6.2",
     "ts-jest": "^29.4.1",
     "ts-node": "^10.9.2",
     "typescript": "^5.9.2"


### PR DESCRIPTION
## Summary
- add Prettier config and script
- integrate ESLint with Prettier and remove overlapping rules
- configure VS Code to format on save

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b445660918832b9e8135fdb00450cc