### PR TITLE
Add Node 22 CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,24 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [22.x]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: npm
+      - run: npm ci
+      - run: npm run lint
+      - run: npm run build
+      - run: npm test


### PR DESCRIPTION
## Summary
- set up GitHub Actions CI to install dependencies and run lint, build, and tests on Node 22

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b4458609f4832b8a62c92278cf70dc