### PR TITLE
feat: centralize logger configuration

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,12 +1,4 @@
-import winston from 'winston';
-const logger = winston.createLogger({
-    level: 'info',
-    format: winston.format.json(),
-    defaultMeta: { service: 'user-service' },
-    transports: [
-        new winston.transports.Console({format: winston.format.simple()})
-    ],
-});
+import logger from './utils/logger';
 const symDiff = (arrOne: number[], arrTwo: number[]): number[] => {
     const diff = arrOne.filter((num)=> !arrTwo.includes(num));
     diff.push(...arrTwo.filter((num)=> !arrOne.includes(num)));

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -1,0 +1,12 @@
+import winston from 'winston';
+
+const logger = winston.createLogger({
+    level: process.env.LOG_LEVEL || 'info',
+    format: winston.format.json(),
+    defaultMeta: { service: 'user-service' },
+    transports: [
+        new winston.transports.Console({format: winston.format.simple()})
+    ],
+});
+
+export default logger;


### PR DESCRIPTION
## Summary
- add reusable Winston logger configured with env-based log level
- use shared logger in index entry point

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b4458e1fdc832b8e9539dd2e52ffb7