### PR TITLE
Add environment configuration module

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+NODE_ENV=development
+PORT=3000

--- a/README.md
+++ b/README.md
@@ -15,3 +15,20 @@ It installs Node.js 22 via the devcontainer `node` feature before running `npm i
 
 This project targets the latest Node.js LTS release. Ensure your environment uses **Node.js 22.x**.
 
+## Configuration
+
+Environment variables are managed with [dotenv](https://www.npmjs.com/package/dotenv).
+Create a `.env` file by copying `.env.example` and updating the values as needed:
+
+```bash
+cp .env.example .env
+```
+
+Load and validate these variables in code through `src/config.ts`:
+
+```ts
+import config from './config';
+
+console.log(`Running in ${config.nodeEnv} mode on port ${config.port}`);
+```
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "dotenv": "^17.2.1",
         "winston": "^3.17.0"
       },
       "devDependencies": {
@@ -2352,6 +2353,18 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "17.2.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.2.1.tgz",
+      "integrity": "sha512-kQhDYKZecqnM0fCnzI5eIv5L4cAe/iRI+HqMbO/hbRdTAeXDG+M9FjipUxNfbARuEg4iHIbhnhs78BCHNbSxEQ==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/electron-to-chromium": {

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "typescript": "^5.9.2"
   },
   "dependencies": {
+    "dotenv": "^17.2.1",
     "winston": "^3.17.0"
   }
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,0 +1,27 @@
+import dotenv from 'dotenv';
+
+dotenv.config();
+
+const getEnv = (name: string, defaultValue?: string): string => {
+    const value = process.env[name] ?? defaultValue;
+    if (value === undefined) {
+        throw new Error(`Missing environment variable: ${name}`);
+    }
+    return value;
+};
+
+export interface AppConfig {
+    nodeEnv: string;
+    port: number;
+}
+
+const config: AppConfig = {
+    nodeEnv: getEnv('NODE_ENV', 'development'),
+    port: Number(getEnv('PORT', '3000')),
+};
+
+if (Number.isNaN(config.port)) {
+    throw new Error('PORT must be a number');
+}
+
+export default config;


### PR DESCRIPTION
## Summary
- Add dotenv dependency and sample `.env.example`
- Introduce `src/config.ts` for loading and validating env vars
- Document environment setup in README

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b4458a0f54832ba1a8ece246d01612